### PR TITLE
Add support to disable returnFocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Type: `String`, Default: `div`, optional
 
 An HTML tag for the FocusTrap's DOM node.
 
+#### returnFocus
+
+Type: `Boolean`, Default: true
+
+If `false`, the focus will not return to the element that triggered the `FocusTrap`.
+
 #### additional props
 
 All props not mentioned above are passed directly to the `<div>` element. This means that you can pass `id`, `className`, `style`, `aria-`attributes, `data-`attributes, or any other arbitrary property that you want to use to customize the element.

--- a/demo/index.html
+++ b/demo/index.html
@@ -53,6 +53,9 @@
     When this FocusTrap activates, the first element in its tab order receives focus,
     <em>but because of positive tabindex attributes the tab order is not the same as the source order</em>.
   </p>
+  <p>
+    Also, when you deactivate this FocusTrap, the focus will not be returned to the button that activated it.
+  </p>
   <div id="demo-four"></div>
 
   <p>

--- a/demo/js/demo-four.jsx
+++ b/demo/js/demo-four.jsx
@@ -24,6 +24,7 @@ var DemoFour = React.createClass({
       <FocusTrap
         onDeactivate={this.unmountTrap}
         className='trap'
+        returnFocus={false}
       >
         <p>
           <button tabIndex='3'>

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var checkedProps = {
   active: PropTypes.bool,
   initialFocus: PropTypes.string,
   tag: PropTypes.string,
+  returnFocus: PropTypes.bool,
 };
 
 var FocusTrap = React.createClass({
@@ -18,6 +19,7 @@ var FocusTrap = React.createClass({
     return {
       active: true,
       tag: 'div',
+      returnFocus: true,
     };
   },
 
@@ -29,14 +31,14 @@ var FocusTrap = React.createClass({
 
   componentDidUpdate: function(prevProps) {
     if (prevProps.active && !this.props.active) {
-      focusTrap.deactivate();
+      focusTrap.deactivate({returnFocus: this.props.returnFocus});
     } else if (!prevProps.active && this.props.active) {
       this.activateTrap();
     }
   },
 
   componentWillUnmount: function() {
-    focusTrap.deactivate();
+    focusTrap.deactivate({returnFocus: this.props.returnFocus});
   },
 
   activateTrap: function() {


### PR DESCRIPTION
There was no support in the react module to define the returnFocus variable of focus-trap.