### PR TITLE
Replace deprecated React.createClass and React.PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 var createFocusTrap = require('focus-trap');
+var createReactClass = require('create-react-class');
 
-var PropTypes = React.PropTypes;
 var checkedProps = {
   active: PropTypes.bool.isRequired,
   paused: PropTypes.bool.isRequired,
@@ -9,7 +10,7 @@ var checkedProps = {
   focusTrapOptions: PropTypes.object.isRequired,
 };
 
-var FocusTrap = React.createClass({
+var FocusTrap = createReactClass({
   propTypes: checkedProps,
 
   getDefaultProps: function() {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "zuul": "^3.10.1"
   },
   "dependencies": {
-    "focus-trap": "^2.0.1"
+    "create-react-class": "^15.5.2",
+    "focus-trap": "^2.0.1",
+    "prop-types": "^15.5.6"
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0",


### PR DESCRIPTION
`React.createClass` and `React.Proptypes` have been deprecated on [React 15.5.0][1], and they recommend using `create-react-class` [if using ES5][2] and [the `prop-types` package][3].

[1]: https://github.com/facebook/react/releases/tag/v15.5.0
[2]: https://facebook.github.io/react/docs/react-without-es6.html
[3]: https://facebook.github.io/react/docs/typechecking-with-proptypes.html