### PR TITLE
CreateClass and PropTypes refactor for React 15.5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
   "env": {
     "node": true,
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true,
+      "jsx": true
     }
   },
   "rules": {
@@ -26,6 +27,6 @@
     "space-before-function-paren": [2, "never"],
     "space-before-blocks": [2, "always"],
     "space-in-parens": [2, "never"],
-    "space-unary-ops": 2,
+    "space-unary-ops": 2
   }
 }

--- a/demo/js/demo-five.jsx
+++ b/demo/js/demo-five.jsx
@@ -1,26 +1,32 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var FocusTrap = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../');
 
-var container = document.getElementById('demo-five');
+const container = document.getElementById('demo-five');
 
-var DemoFive = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoFive extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       activeTrap: false,
     };
-  },
 
-  mountTrap: function() {
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+  }
+
+  mountTrap() {
     this.setState({ activeTrap: true });
-  },
+  }
 
-  unmountTrap: function() {
+  unmountTrap() {
     this.setState({ activeTrap: false });
-  },
+  }
 
-  render: function() {
-    var trap = (this.state.activeTrap) ? (
+  render() {
+    const trap = (this.state.activeTrap) ? (
       <FocusTrap
         focusTrapOptions={{
           onDeactivate: this.unmountTrap,
@@ -34,7 +40,7 @@ var DemoFive = React.createClass({
             <a href='#'>Another focusable thing</a>
           </div>
           <div>
-            Autofocused input: <input autoFocus={true} />
+            Autofocused input: <input autoFocus={true}/>
           </div>
         </div>
       </FocusTrap>
@@ -50,7 +56,7 @@ var DemoFive = React.createClass({
         {trap}
       </div>
     );
-  },
-});
+  }
+}
 
 ReactDOM.render(<DemoFive />, container);

--- a/demo/js/demo-four.jsx
+++ b/demo/js/demo-four.jsx
@@ -1,26 +1,32 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var FocusTrap = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../');
 
-var container = document.getElementById('demo-four');
+const container = document.getElementById('demo-four');
 
-var DemoFour = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoFour extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       activeTrap: false,
     };
-  },
 
-  mountTrap: function() {
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+  }
+
+  mountTrap() {
     this.setState({ activeTrap: true });
-  },
+  }
 
-  unmountTrap: function() {
+  unmountTrap() {
     this.setState({ activeTrap: false });
-  },
+  }
 
-  render: function() {
-    var trap = (this.state.activeTrap) ? (
+  render() {
+    const trap = (this.state.activeTrap) ? (
       <FocusTrap
         className='trap'
         focusTrapOptions={{
@@ -65,7 +71,7 @@ var DemoFour = React.createClass({
         {trap}
       </div>
     );
-  },
-});
+  }
+}
 
 ReactDOM.render(<DemoFour />, container);

--- a/demo/js/demo-one.jsx
+++ b/demo/js/demo-one.jsx
@@ -1,29 +1,35 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var FocusTrap = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../');
 
-var container = document.getElementById('demo-one');
+const container = document.getElementById('demo-one');
 
-var DemoOne = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoOne extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       activeTrap: false,
     };
-  },
 
-  mountTrap: function() {
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+  }
+
+  mountTrap() {
     this.setState({ activeTrap: true });
-  },
+  }
 
-  unmountTrap: function() {
+  unmountTrap() {
     this.setState({ activeTrap: false });
-  },
+  }
 
-  render: function() {
-    var trap = (this.state.activeTrap) ? (
+  render() {
+    const trap = (this.state.activeTrap) ? (
       <FocusTrap
         focusTrapOptions={{
-          onDeactivate: this.unmountTrap
+          onDeactivate: this.unmountTrap,
         }}
       >
         <div className='trap'>
@@ -49,7 +55,8 @@ var DemoOne = React.createClass({
         {trap}
       </div>
     );
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoOne />, container);

--- a/demo/js/demo-three.jsx
+++ b/demo/js/demo-three.jsx
@@ -1,26 +1,32 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var FocusTrap = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../');
 
-var container = document.getElementById('demo-three');
+const container = document.getElementById('demo-three');
 
-var DemoThree = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoThree extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       activeTrap: false,
     };
-  },
 
-  mountTrap: function() {
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+  }
+
+  mountTrap() {
     this.setState({ activeTrap: true });
-  },
+  }
 
-  unmountTrap: function() {
+  unmountTrap() {
     this.setState({ activeTrap: false });
-  },
+  }
 
-  render: function() {
-    var trapClass = 'trap';
+  render() {
+    let trapClass = 'trap';
     if (this.state.activeTrap) trapClass += ' is-active';
 
     return (
@@ -42,18 +48,19 @@ var DemoThree = React.createClass({
             clickOutsideDeactivates: true,
           }}
         >
-        <p>
-          Here is a focus trap <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a> parts.
-        </p>
-        <p>
-          <button onClick={this.unmountTrap}>
-            deactivate trap
-          </button>
-        </p>
-      </FocusTrap>
+          <p>
+            Here is a focus trap <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a> parts.
+          </p>
+          <p>
+            <button onClick={this.unmountTrap}>
+              deactivate trap
+            </button>
+          </p>
+        </FocusTrap>
       </div>
     );
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoThree />, container);

--- a/demo/js/demo-two.jsx
+++ b/demo/js/demo-two.jsx
@@ -1,26 +1,32 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var FocusTrap = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../');
 
-var container = document.getElementById('demo-two');
+const container = document.getElementById('demo-two');
 
-var DemoTwo = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoTwo extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       activeTrap: false,
     };
-  },
 
-  mountTrap: function() {
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+  }
+
+  mountTrap() {
     this.setState({ activeTrap: true });
-  },
+  }
 
-  unmountTrap: function() {
+  unmountTrap() {
     this.setState({ activeTrap: false });
-  },
+  }
 
-  render: function() {
-    var trap = (this.state.activeTrap) ? (
+  render() {
+    const trap = (this.state.activeTrap) ? (
       <FocusTrap
         className='trap'
         focusTrapOptions={{
@@ -36,7 +42,7 @@ var DemoTwo = React.createClass({
           <label htmlFor='focused-input' style={{ marginRight: 10 }}>
             Initially focused input
           </label>
-          <input ref='input' id='focused-input' />
+          <input ref='input' id='focused-input'/>
         </p>
         <p>
           <button onClick={this.unmountTrap}>
@@ -56,7 +62,8 @@ var DemoTwo = React.createClass({
         {trap}
       </div>
     );
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoTwo />, container);

--- a/index.js
+++ b/index.js
@@ -1,43 +1,33 @@
-var React = require('react');
-var createFocusTrap = require('focus-trap');
+const React = require('react');
+const PropTypes = require('prop-types');
+const createFocusTrap = require('focus-trap');
 
-var PropTypes = React.PropTypes;
-var checkedProps = {
+const checkedProps = {
   active: PropTypes.bool.isRequired,
   paused: PropTypes.bool.isRequired,
   tag: PropTypes.string.isRequired,
   focusTrapOptions: PropTypes.object.isRequired,
 };
 
-var FocusTrap = React.createClass({
-  propTypes: checkedProps,
+class FocusTrap extends React.Component {
 
-  getDefaultProps: function() {
-    return {
-      active: true,
-      tag: 'div',
-      paused: false,
-      focusTrapOptions: {},
-    };
-  },
-
-  componentWillMount: function() {
+  componentWillMount() {
     if (typeof document !== 'undefined') {
       this.previouslyFocusedElement = document.activeElement;
     }
-  },
+  }
 
-  componentDidMount: function() {
+  componentDidMount() {
     // We need to hijack the returnFocusOnDeactivate option,
     // because React can move focus into the element before we arrived at
     // this lifecycle hook (e.g. with autoFocus inputs). So the component
     // captures the previouslyFocusedElement in componentWillMount,
     // then (optionally) returns focus to it in componentWillUnmount.
-    var specifiedFocusTrapOptions = this.props.focusTrapOptions;
-    var tailoredFocusTrapOptions = {
+    const specifiedFocusTrapOptions = this.props.focusTrapOptions;
+    const tailoredFocusTrapOptions = {
       returnFocusOnDeactivate: false,
     };
-    for (var optionName in specifiedFocusTrapOptions) {
+    for (const optionName in specifiedFocusTrapOptions) {
       if (!specifiedFocusTrapOptions.hasOwnProperty(optionName)) continue;
       if (optionName === 'returnFocusOnDeactivate') continue;
       tailoredFocusTrapOptions[optionName] = specifiedFocusTrapOptions[optionName];
@@ -50,9 +40,9 @@ var FocusTrap = React.createClass({
     if (this.props.paused) {
       this.focusTrap.pause();
     }
-  },
+  }
 
-  componentDidUpdate: function(prevProps) {
+  componentDidUpdate(prevProps) {
     if (prevProps.active && !this.props.active) {
       this.focusTrap.deactivate();
     } else if (!prevProps.active && this.props.active) {
@@ -64,31 +54,43 @@ var FocusTrap = React.createClass({
     } else if (!prevProps.paused && this.props.paused) {
       this.focusTrap.pause();
     }
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     this.focusTrap.deactivate();
     if (this.props.focusTrapOptions.returnFocusOnDeactivate !== false && this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus();
     }
-  },
+  }
 
-  render: function() {
-    var props = this.props;
+  render() {
+    const props = this.props;
 
-    var elementProps = {
-      ref: function(el) { this.node = el; }.bind(this),
+    const elementProps = {
+      ref: function(el) {
+        this.node = el;
+      }.bind(this),
     };
 
     // This will get id, className, style, etc. -- arbitrary element props
-    for (var prop in props) {
+    for (const prop in props) {
       if (!props.hasOwnProperty(prop)) continue;
       if (checkedProps[prop]) continue;
       elementProps[prop] = props[prop];
     }
 
     return React.createElement(this.props.tag, elementProps, this.props.children);
-  },
-});
+  }
+
+}
+
+FocusTrap.propTypes = checkedProps;
+
+FocusTrap.defaultProps = {
+  active: true,
+  tag: 'div',
+  paused: false,
+  focusTrapOptions: {},
+};
 
 module.exports = FocusTrap;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "zuul": "^3.10.1"
   },
   "dependencies": {
-    "focus-trap": "^2.0.1"
+    "focus-trap": "^2.0.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,9 +1753,9 @@ faye-websocket@~0.10.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
+fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3494,6 +3494,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proxy-addr@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.2.tgz#b4cc5f22610d9535824c123aef9d3cf73c40ba37"
@@ -3619,21 +3625,23 @@ react-addons-test-utils@^15.1.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dom@^15.1.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react@^15.1.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-only-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
With the release of React 15.5 the use of CreateClass instead of ES6 classes and referencing PropTypes from React itself are marked as deprecation warnings and this will be removed in React 16.

These changes re-establishes full compatibility with the latest React releases.