### PR TITLE
Check for focus before calling to fix IE 11/iFrame bug

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -1,17 +1,17 @@
-const React = require("react");
-const createFocusTrap = require("focus-trap");
+const React = require('react');
+const createFocusTrap = require('focus-trap');
 
 const checkedProps = [
-  "active",
-  "paused",
-  "tag",
-  "focusTrapOptions",
-  "_createFocusTrap"
+  'active',
+  'paused',
+  'tag',
+  'focusTrapOptions',
+  '_createFocusTrap'
 ];
 
 class FocusTrap extends React.Component {
   componentWillMount() {
-    if (typeof document !== "undefined") {
+    if (typeof document !== 'undefined') {
       this.previouslyFocusedElement = document.activeElement;
     }
   }
@@ -28,7 +28,7 @@ class FocusTrap extends React.Component {
     };
     for (const optionName in specifiedFocusTrapOptions) {
       if (!specifiedFocusTrapOptions.hasOwnProperty(optionName)) continue;
-      if (optionName === "returnFocusOnDeactivate") continue;
+      if (optionName === 'returnFocusOnDeactivate') continue;
       tailoredFocusTrapOptions[optionName] =
         specifiedFocusTrapOptions[optionName];
     }
@@ -96,7 +96,7 @@ class FocusTrap extends React.Component {
 
 FocusTrap.defaultProps = {
   active: true,
-  tag: "div",
+  tag: 'div',
   paused: false,
   focusTrapOptions: {},
   _createFocusTrap: createFocusTrap

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -1,17 +1,17 @@
-const React = require('react');
-const createFocusTrap = require('focus-trap');
+const React = require("react");
+const createFocusTrap = require("focus-trap");
 
 const checkedProps = [
-  'active',
-  'paused',
-  'tag',
-  'focusTrapOptions',
-  '_createFocusTrap'
+  "active",
+  "paused",
+  "tag",
+  "focusTrapOptions",
+  "_createFocusTrap"
 ];
 
 class FocusTrap extends React.Component {
   componentWillMount() {
-    if (typeof document !== 'undefined') {
+    if (typeof document !== "undefined") {
       this.previouslyFocusedElement = document.activeElement;
     }
   }
@@ -28,7 +28,7 @@ class FocusTrap extends React.Component {
     };
     for (const optionName in specifiedFocusTrapOptions) {
       if (!specifiedFocusTrapOptions.hasOwnProperty(optionName)) continue;
-      if (optionName === 'returnFocusOnDeactivate') continue;
+      if (optionName === "returnFocusOnDeactivate") continue;
       tailoredFocusTrapOptions[optionName] =
         specifiedFocusTrapOptions[optionName];
     }
@@ -63,17 +63,10 @@ class FocusTrap extends React.Component {
     this.focusTrap.deactivate();
     if (
       this.props.focusTrapOptions.returnFocusOnDeactivate !== false &&
-      this.previouslyFocusedElement
+      this.previouslyFocusedElement &&
+      this.previouslyFocusedElement.focus
     ) {
-      /*
-        IE 11 in an iFrame some times returns an empty object
-        for document.activeElement if that element has a tab index.
-      */
-      try {
-        this.previouslyFocusedElement.focus();
-      } catch (error) {
-        console.error('Error attempting focus on previously focused element', error)
-      }
+      this.previouslyFocusedElement.focus();
     }
   }
 
@@ -103,7 +96,7 @@ class FocusTrap extends React.Component {
 
 FocusTrap.defaultProps = {
   active: true,
-  tag: 'div',
+  tag: "div",
   paused: false,
   focusTrapOptions: {},
   _createFocusTrap: createFocusTrap

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -65,7 +65,15 @@ class FocusTrap extends React.Component {
       this.props.focusTrapOptions.returnFocusOnDeactivate !== false &&
       this.previouslyFocusedElement
     ) {
-      this.previouslyFocusedElement.focus();
+      /*
+        IE 11 in an iFrame some times returns an empty object
+        for document.activeElement if that element has a tab index.
+      */
+      try {
+        this.previouslyFocusedElement.focus();
+      } catch (error) {
+        console.error('Error attempting focus on previously focused element', error)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/davidtheclark/focus-trap-react/issues/18

I've run into a bug in IE 11 when used in an iFrame.  In that scenario, `document.activeElement` randomly returns an empty object if the element in question has a tab index.  Attempting to call `.focus()` on this empty object blows up with the following error in the console.

![screen shot 2017-10-18 at 10 07 10 am](https://user-images.githubusercontent.com/6463914/31729748-2da88128-b3ed-11e7-9ad2-f95b05e37c1d.png)

I'm submitting this PR to wrap the `.focus()` call in a try/catch to prevent the app from blowing up in this particular edge case with IE 11 and iFrames.

After the try/catch the app continues to work as expected minus returning focus and console logs the provided error as shown in this screen shot.

![screen shot 2017-10-18 at 10 11 08 am](https://user-images.githubusercontent.com/6463914/31729841-75cbb240-b3ed-11e7-9dbc-62a416d89e6b.png)

Please let me know if you need any more information or clarification and thank you for the library! 👍 
