### PR TITLE
adjust types so that props are available on the imported namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,17 @@
-declare module "focus-trap-react" {
-  import { Options as FocusTrapOptions } from "focus-trap";
-  import * as React from "react";
+import { Options as FocusTrapOptions } from 'focus-trap';
+import * as React from 'react';
 
-  // Extend AllHTMLAttributes to provide completions on DOM properties wherever
-  // React does.
-  interface Props extends React.AllHTMLAttributes<any> {
+export = FocusTrap;
+
+declare namespace FocusTrap {
+  export interface Props extends React.AllHTMLAttributes<any> {
     active?: boolean;
     paused?: boolean;
     tag?: string;
     focusTrapOptions?: FocusTrapOptions;
     // Allow through any properties that weren't picked up
-    [x: string]: any;
+    [prop: string]: any;
   }
-
-  class FocusTrap extends React.Component<Props> {}
-  namespace FocusTrap {}
-
-  export = FocusTrap;
 }
+
+declare class FocusTrap extends React.Component<FocusTrap.Props> {}


### PR DESCRIPTION
This should resolve the issue described here: https://github.com/davidtheclark/focus-trap-react/pull/22#discussion_r159297573

cc: @TedDriggs