### PR TITLE
fix: add typescript declaration file to publish files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "keywords": [
     "react",


### PR DESCRIPTION
Hi @davidtheclark

A recent update to the library no longer includes the type declarations. This PR adds the declaration file to the list of published files.