### PR TITLE
New API with Single Required Child / Do Not Add Tags into DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,28 +75,28 @@ class DemoOne extends React.Component {
   render() {
     const trap = this.state.activeTrap
       ? <FocusTrap
+          component="div"
           focusTrapOptions={{
             onDeactivate: this.unmountTrap
           }}
+          className="trap"
         >
-          <div className="trap">
-            <p>
-              Here is a focus trap
-              {' '}
-              <a href="#">with</a>
-              {' '}
-              <a href="#">some</a>
-              {' '}
-              <a href="#">focusable</a>
-              {' '}
-              parts.
-            </p>
-            <p>
-              <button onClick={this.unmountTrap}>
-                deactivate trap
-              </button>
-            </p>
-          </div>
+          <p>
+            Here is a focus trap
+            {' '}
+            <a href="#">with</a>
+            {' '}
+            <a href="#">some</a>
+            {' '}
+            <a href="#">focusable</a>
+            {' '}
+            parts.
+          </p>
+          <p>
+            <button onClick={this.unmountTrap}>
+              deactivate trap
+            </button>
+          </p>
         </FocusTrap>
       : false;
 
@@ -138,11 +138,11 @@ Type: `Boolean`, optional
 
 If you would like to pause or unpause the focus trap (see [`focus-trap`'s documentation](https://github.com/davidtheclark/focus-trap#focustrappause)), toggle this prop.
 
-#### tag
+#### component
 
-Type: `String`, Default: `div`, optional
+Type: `React.Component | String`, required
 
-An HTML tag for the FocusTrap's DOM node.
+A React component or HTML element to trap the focus in.
 
 #### additional props
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,28 @@ Why? Because this module's core functionality comes from focus-trap, which uses 
 
 ## Usage
 
-Read code in `demo/` (it's very simple), and [see how it works](http://davidtheclark.github.io/focus-trap-react/demo/).
+You wrap any element that you want to act as a focus trap with the `<FocusTrap>` component. `<FocusTrap>` expects exactly one child element which can be any HTML element or other React component that contains focusable elements.
 
-Here's one simple example:
+For example:
+
+```js
+<FocusTrap>
+  <div id="modal-dialog" className="modal" >
+    <button>Ok</button>
+    <button>Cancel</button>
+  </div>
+</FocusTrap>
+```
+
+```js
+<FocusTrap>
+  <ModalDialog okButtonText="Ok" cancelButtonText="Cancel" />
+</FocusTrap>
+```
+
+You can read further code examples in `demo/` (it's very simple), and [see how it works](http://davidtheclark.github.io/focus-trap-react/demo/).
+
+Here's one more simple example:
 
 ```js
 const React = require('react');
@@ -137,16 +156,6 @@ See `demo/demo-three.jsx`.
 Type: `Boolean`, optional
 
 If you would like to pause or unpause the focus trap (see [`focus-trap`'s documentation](https://github.com/davidtheclark/focus-trap#focustrappause)), toggle this prop.
-
-#### component
-
-Type: `React.Component | String`, required
-
-A React component or HTML element to trap the focus in.
-
-#### additional props
-
-All props not mentioned above are passed directly to the rendered DOM element. This means that you can pass `id`, `className`, `style`, `aria-`attributes, `data-`attributes, or any other arbitrary property that you want to use to customize the element.
 
 ## Contributing & Development
 

--- a/demo/js/demo-ffne.js
+++ b/demo/js/demo-ffne.js
@@ -34,28 +34,30 @@ class DemoFfne extends React.Component {
             escapeDeactivates: false
           }}
         >
-          <p>
-            Here is a focus trap
-            {' '}
-            <a href="#">with</a>
-            {' '}
-            <a href="#">some</a>
-            {' '}
-            <a href="#">focusable</a>
-            {' '}
-            parts.
-          </p>
-          <p>
-            <label htmlFor="focused-input" style={{ marginRight: 10 }}>
-              Initially focused input
-            </label>
-            <input ref="input" id="focused-input" />
-          </p>
-          <p>
-            <button onClick={this.unmountTrap}>
-              deactivate trap
-            </button>
-          </p>
+          <div class="trap">
+            <p>
+              Here is a focus trap
+              {' '}
+              <a href="#">with</a>
+              {' '}
+              <a href="#">some</a>
+              {' '}
+              <a href="#">focusable</a>
+              {' '}
+              parts.
+            </p>
+            <p>
+              <label htmlFor="focused-input" style={{ marginRight: 10 }}>
+                Initially focused input
+              </label>
+              <input ref="input" id="focused-input" />
+            </p>
+            <p>
+              <button onClick={this.unmountTrap}>
+                deactivate trap
+              </button>
+            </p>
+          </div>
         </FocusTrap>
       : false;
 

--- a/demo/js/demo-special-element.js
+++ b/demo/js/demo-special-element.js
@@ -36,33 +36,35 @@ class DemoSpecialElement extends React.Component {
           </button>
         </p>
         <FocusTrap
-          id="focus-trap-three"
-          tag="section"
-          style={{ background: '#eee' }}
-          data-whatever="nothing"
           active={this.state.activeTrap}
-          className={trapClass}
           focusTrapOptions={{
             onDeactivate: this.unmountTrap,
             clickOutsideDeactivates: true
           }}
         >
-          <p>
-            Here is a focus trap
-            {' '}
-            <a href="#">with</a>
-            {' '}
-            <a href="#">some</a>
-            {' '}
-            <a href="#">focusable</a>
-            {' '}
-            parts.
-          </p>
-          <p>
-            <button onClick={this.unmountTrap}>
-              deactivate trap
-            </button>
-          </p>
+          <section
+            id="focus-trap-three"
+            style={{ background: '#eee' }}
+            data-whatever="nothing"
+            className={trapClass}
+          >
+            <p>
+              Here is a focus trap
+              {' '}
+              <a href="#">with</a>
+              {' '}
+              <a href="#">some</a>
+              {' '}
+              <a href="#">focusable</a>
+              {' '}
+              parts.
+            </p>
+            <p>
+              <button onClick={this.unmountTrap}>
+                deactivate trap
+              </button>
+            </p>
+          </section>
         </FocusTrap>
       </div>
     );

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export = FocusTrap;
 
 declare namespace FocusTrap {
   export interface Props extends React.AllHTMLAttributes<any> {
+    children: React.ReactElement;
     active?: boolean;
     paused?: boolean;
     tag?: string;
@@ -14,4 +15,4 @@ declare namespace FocusTrap {
   }
 }
 
-declare class FocusTrap extends React.Component<FocusTrap.Props> {}
+declare class FocusTrap extends React.Component<FocusTrap.Props> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,7 @@ declare namespace FocusTrap {
     children: React.ReactElement;
     active?: boolean;
     paused?: boolean;
-    tag?: string;
     focusTrapOptions?: FocusTrapOptions;
-    // Allow through any properties that weren't picked up
-    [prop: string]: any;
   }
 }
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -1,13 +1,6 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 const createFocusTrap = require('focus-trap');
-
-const checkedProps = [
-  'active',
-  'paused',
-  'tag',
-  'focusTrapOptions',
-  '_createFocusTrap'
-];
 
 class FocusTrap extends React.Component {
   constructor(props) {
@@ -35,8 +28,10 @@ class FocusTrap extends React.Component {
         specifiedFocusTrapOptions[optionName];
     }
 
+    const focusTrapElementDOMNode = ReactDOM.findDOMNode(this.focusTrapElement);
+
     this.focusTrap = this.props._createFocusTrap(
-      this.node,
+      focusTrapElementDOMNode,
       tailoredFocusTrapOptions
     );
     if (this.props.active) {
@@ -75,27 +70,24 @@ class FocusTrap extends React.Component {
     }
   }
 
-  setNode = el => {
-    this.node = el;
+  setFocusTrapElement = element => {
+    this.focusTrapElement = element;
   };
 
   render() {
-    const elementProps = {
-      ref: this.setNode
-    };
+    const child = React.Children.only(this.props.children);
 
-    // This will get id, className, style, etc. -- arbitrary element props
-    for (const prop in this.props) {
-      if (!this.props.hasOwnProperty(prop)) continue;
-      if (checkedProps.indexOf(prop) !== -1) continue;
-      elementProps[prop] = this.props[prop];
+
+    const composedRefCallback = element => {
+      this.setFocusTrapElement(element);
+      if (typeof child.ref === 'function') {
+        child.ref(element);
+      }
     }
 
-    return React.createElement(
-      this.props.tag,
-      elementProps,
-      this.props.children
-    );
+    const childWithRef = React.cloneElement(child, { ref: composedRefCallback });
+
+    return childWithRef;
   }
 }
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -77,7 +77,6 @@ class FocusTrap extends React.Component {
   render() {
     const child = React.Children.only(this.props.children);
 
-
     const composedRefCallback = element => {
       this.setFocusTrapElement(element);
       if (typeof child.ref === 'function') {
@@ -93,7 +92,6 @@ class FocusTrap extends React.Component {
 
 FocusTrap.defaultProps = {
   active: true,
-  tag: 'div',
   paused: false,
   focusTrapOptions: {},
   _createFocusTrap: createFocusTrap

--- a/test/activation.test.js
+++ b/test/activation.test.js
@@ -55,12 +55,14 @@ describe('activation', () => {
           initialFocus: '#initial-focusee'
         }}
       >
-        <button>
-          something special
-        </button>
-        <button id="initial-focusee">
-          another thing
-        </button>
+        <div>
+          <button>
+            something special
+          </button>
+          <button id="initial-focusee">
+            another thing
+          </button>
+        </div>
       </FocusTrap>,
       domContainer
     );

--- a/test/deactivation.test.js
+++ b/test/deactivation.test.js
@@ -118,10 +118,10 @@ describe('deactivation', () => {
       render() {
         const trap = this.state.trapActive
           ? <FocusTrap _createFocusTrap={mockCreateFocusTrap} ref="trap">
-            <button>
-              something special
+              <button>
+                something special
               </button>
-          </FocusTrap>
+            </FocusTrap>
           : false;
 
         return (

--- a/test/deactivation.test.js
+++ b/test/deactivation.test.js
@@ -44,9 +44,11 @@ describe('deactivation', () => {
               _createFocusTrap={mockCreateFocusTrap}
               active={this.state.trapActive}
             >
-              <button>
-                something special
-              </button>
+              <div>
+                <button>
+                  something special
+                </button>
+              </div>
             </FocusTrap>
           </div>
         );
@@ -83,9 +85,11 @@ describe('deactivation', () => {
               active={this.state.trapActive}
               focusTrapOptions={{ returnFocusOnDeactivate: true }}
             >
-              <button>
-                something special
-              </button>
+              <div>
+                <button>
+                  something special
+                </button>
+              </div>
             </FocusTrap>
           </div>
         );
@@ -93,7 +97,7 @@ describe('deactivation', () => {
     }
 
     const zone = ReactDOM.render(<TestZone />, domContainer);
-    // mock deactivate on the fouscTrap instance for we can asset 
+    // mock deactivate on the fouscTrap instance for we can asset
     // that we are passing the correct config to the focus trap.
     zone.trap.focusTrap.deactivate = jest.fn();
 
@@ -101,7 +105,6 @@ describe('deactivation', () => {
 
     expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({ returnFocus: true });
   });
-  
   test('deactivation by dismount', () => {
     class TestZone extends React.Component {
       state = {
@@ -115,10 +118,10 @@ describe('deactivation', () => {
       render() {
         const trap = this.state.trapActive
           ? <FocusTrap _createFocusTrap={mockCreateFocusTrap} ref="trap">
-              <button>
-                something special
+            <button>
+              something special
               </button>
-            </FocusTrap>
+          </FocusTrap>
           : false;
 
         return (

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -26,9 +26,11 @@ describe('dom', () => {
   test('DOM with only required props', () => {
     const trap = TestUtils.renderIntoDocument(
       <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
-        <button>
-          something special
-        </button>
+        <div>
+          <button>
+            something special
+          </button>
+        </div>
       </FocusTrap>
     );
     const trapNode = ReactDOM.findDOMNode(trap);
@@ -44,15 +46,15 @@ describe('dom', () => {
 
   test('DOM with all possible DOM-related props', () => {
     const trap = TestUtils.renderIntoDocument(
-      <FocusTrap
-        _createFocusTrap={mockCreateFocusTrap}
-        id="foo"
-        className="bar"
-        tag="figure"
-      >
-        <button>
-          something special
-        </button>
+      <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
+        <figure
+          id="foo"
+          className="bar"
+        >
+          <button>
+            something special
+          </button>
+        </figure>
       </FocusTrap>
     );
     const trapNode = ReactDOM.findDOMNode(trap);

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -67,13 +67,21 @@ describe('dom', () => {
     expect(trapNode.firstChild.innerHTML).toBe('something special');
   });
 
-  test('FocusTrap with no child provided to it', () => {
+  test('FocusTrap throws with no child provided to it', () => {
     expect(() => TestUtils.renderIntoDocument(
       <FocusTrap _createFocusTrap={mockCreateFocusTrap} />
     )).toThrowError('expected to receive a single React element child');
   });
 
-  test('FocusTrap with multiple children provided to it', () => {
+  test('FocusTrap throws with a plain text child provided to it', () => {
+    expect(() => TestUtils.renderIntoDocument(
+      <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
+        Some text that is not a DOM node
+      </FocusTrap>
+    )).toThrowError('expected to receive a single React element child');
+  });
+
+  test('FocusTrap throws with multiple children provided to it', () => {
     expect(() => TestUtils.renderIntoDocument(
       <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
         <div>First div</div>

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -81,4 +81,16 @@ describe('dom', () => {
       </FocusTrap>
     )).toThrowError('expected to receive a single React element child');
   });
+
+  test('FocusTrap preserves child ref by composing', () => {
+    const childRef = jest.fn();
+
+    TestUtils.renderIntoDocument(
+      <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
+        <div ref={childRef}></div>
+      </FocusTrap>
+    );
+
+    expect(childRef).toHaveBeenCalledTimes(1);
+  })
 });

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -16,11 +16,19 @@ describe('dom', () => {
     mockCreateFocusTrap = jest.fn(() => mockFocusTrap);
     domContainer = document.createElement('div');
     document.body.appendChild(domContainer);
+
+    // This surpresses React error boundary logs for testing intentionally
+    // thrown errors, like in some test cases in this suite. See discussion of
+    // this here: https://github.com/facebook/react/issues/11098
+    jest.spyOn(console, 'error')
+    global.console.error.mockImplementation(() => { })
   });
 
   afterEach(() => {
     ReactDOM.unmountComponentAtNode(domContainer);
     document.body.removeChild(domContainer);
+
+    global.console.error.mockRestore()
   });
 
   test('DOM with only required props', () => {

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -66,4 +66,19 @@ describe('dom', () => {
     expect(trapNode.firstChild.tagName).toBe('BUTTON');
     expect(trapNode.firstChild.innerHTML).toBe('something special');
   });
+
+  test('FocusTrap with no child provided to it', () => {
+    expect(() => TestUtils.renderIntoDocument(
+      <FocusTrap _createFocusTrap={mockCreateFocusTrap} />
+    )).toThrowError('expected to receive a single React element child');
+  });
+
+  test('FocusTrap with multiple children provided to it', () => {
+    expect(() => TestUtils.renderIntoDocument(
+      <FocusTrap _createFocusTrap={mockCreateFocusTrap}>
+        <div>First div</div>
+        <div>Second div</div>
+      </FocusTrap>
+    )).toThrowError('expected to receive a single React element child');
+  });
 });


### PR DESCRIPTION
**UPDATED**:

Prior to this PR the `FocusTrap` component was expected to be passed in a `tag` property or default to a `div` tag.

Wrapping anything with a `<FocusTrap>` would cause a wrapping DOM node to be created (by default a `div`). This breaks CSS rules like when the parent of the focus-trapped element has a `display: flex` rule that only extends to its direct children. The newly created `div` tag would be the only direct child of the parent and the styling is broken.

This PR introduces a new API with new behavior. Instead of rendering a new tag or component which then acts as a focus trap around the user-provided child element, `<FocusTrap>` now just renders that child element directly while attaching focus trap behavior to that element.

In order for this to work the internally stored DOM node reference needs to be fetched via `ReactDOM.findDOMnode` since the component that can be passed in might have several layers of React components until it resolves in a DOM Node.

Thus it's now required to use `<FocusTrap>` with a single child element that resolved to a DOM node (e.g. no text as children allowed). 

The advantage is that `FocusTrap` ultimately does not change anything about the DOM hierarchy and the chance of breaking a flexbox layout is eliminated.

