### PR TITLE
fix broken generic in index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export = FocusTrap;
 
 declare namespace FocusTrap {
   export interface Props extends React.AllHTMLAttributes<any> {
-    children: React.ReactElement;
+    children: React.ReactElement<any>;
     active?: boolean;
     paused?: boolean;
     focusTrapOptions?: FocusTrapOptions;


### PR DESCRIPTION
`React.ReactElement<P>` is a generic and requires a type argument. This fixes that.