### PR TITLE
Feature/bump focus trap 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3184,11 +3184,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-3.0.0.tgz",
-      "integrity": "sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+      "integrity": "sha1-TuK5ZUfJ6g5CUqLUssymiUQZRmM=",
       "requires": {
-        "tabbable": "^3.1.0",
+        "tabbable": "^3.1.2",
         "xtend": "^4.0.1"
       }
     },
@@ -8769,9 +8769,9 @@
       }
     },
     "tabbable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.0.tgz",
-      "integrity": "sha512-W+w8dbSbQiuhMQhJbgtSn7ksg1Z+Z0UQq0WpDuYUrXjqie2bkMTfXRhdKtyQ8lRbppDWFoQf+S3T+OBGxoEPUA=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha1-8tFszNAfQA44Y1xxga3+CtllpKI="
     },
     "table": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^16.0.0"
   },
   "dependencies": {
-    "focus-trap": "^3.0.0"
+    "focus-trap": "^4.0.0"
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0 || ^16.0.0",


### PR DESCRIPTION
P.R bumps focus-trap to 4.x version.

This resolves a number of issues for us regarding nested focus traps. I believe the commit will also resolve #27.

Ive verified Unit tests pass and for my usage - there were no other upgrade steps we needed to do.