### PR TITLE
Support object refs

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -82,6 +82,9 @@ class FocusTrap extends React.Component {
       if (typeof child.ref === 'function') {
         child.ref(element);
       }
+      if (typeof child.ref === 'object') {
+        child.ref.current = element;
+      }
     }
 
     const childWithRef = React.cloneElement(child, { ref: composedRefCallback });


### PR DESCRIPTION
Add support for [`React.createRef()`](https://reactjs.org/docs/react-api.html#reactcreateref)