### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export = FocusTrap;
 
 declare namespace FocusTrap {
   export interface Props extends React.AllHTMLAttributes<any> {
-    children: React.ReactElement<any>;
+    children: React.ReactNode;
     active?: boolean;
     paused?: boolean;
     focusTrapOptions?: FocusTrapOptions;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22725671/74199680-d42cc100-4c32-11ea-8b57-e71a6cbccd18.png)

children's type is `React.ReactNode` and not `React.ReactElement`

See `@types/react`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L773