### PR TITLE
Update focus-trap dependency to v5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3184,11 +3184,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
-      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-5.1.0.tgz",
+      "integrity": "sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==",
       "requires": {
-        "tabbable": "^3.1.2",
+        "tabbable": "^4.0.0",
         "xtend": "^4.0.1"
       }
     },
@@ -8769,9 +8769,9 @@
       }
     },
     "tabbable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
-      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
     },
     "table": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^16.0.0"
   },
   "dependencies": {
-    "focus-trap": "^4.0.2"
+    "focus-trap": "^5.1.0"
   },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0 || ^16.0.0",

--- a/test/deactivation.test.js
+++ b/test/deactivation.test.js
@@ -82,6 +82,7 @@ describe('deactivation', () => {
             </button>
             <FocusTrap
               ref={(component) => this.trap = component}
+              _createFocusTrap={mockCreateFocusTrap}
               active={this.state.trapActive}
               focusTrapOptions={{ returnFocusOnDeactivate: true }}
             >


### PR DESCRIPTION
Some of the latest `focus-trap` options are still not available for `focus-trap-react`. This PR makes them available, by updating to the latest version.

A test was also updated in order to prevent the activation to fail due to non-focusable element (a verification that wasn't being made in the past)