### PR TITLE
fix: Allow mutable object refs to be used for FocusTrap child

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -81,6 +81,8 @@ class FocusTrap extends React.Component {
       this.setFocusTrapElement(element);
       if (typeof child.ref === 'function') {
         child.ref(element);
+      } else if (child.ref) {
+        child.ref.current = element;
       }
     }
 


### PR DESCRIPTION
# What
- Fixes https://github.com/davidtheclark/focus-trap-react/issues/50
- Allows mutable object refs, created by `React.createRef()`, to be used on the first child of the `<FocusTrap>` component

# Testing

Here is a simple sample component that demonstrates the problem and the fix.
The problem is more prevalent when using the newer React Hooks, since most refs will be mutable object refs instead of callbacks.


```
import React from 'react';
import FocusTrap from 'focus-trap-react';

class Example extends React.PureComponent {
  constructor(props) {
    super(props);
    this.ref = React.createRef();
  }
  
  componentDidMount() {
    if (!this.ref.current) {
      throw new Error('ref.current should be a reference to the button!');
    }
  }

  render() {
    return (
      <FocusTrap>
        <button ref={this.ref}>
          Button
        </button>
      </FocusTrap>
    );
  }
}
```